### PR TITLE
A url of javascript include tag is too old for Chartkick 3.x.

### DIFF
--- a/app/views/layouts/content_only.html.erb
+++ b/app/views/layouts/content_only.html.erb
@@ -28,7 +28,7 @@
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
-  <%= javascript_include_tag "//www.google.com/jsapi", "chartkick" %>
+  <%= javascript_include_tag "https://www.gstatic.com/charts/loader.js" %>
 </head>
 <body>
 


### PR DESCRIPTION
Update a url of the Google Charts library.
